### PR TITLE
Changed 'GetEvent' call to 'PollEvent' due to rename in SFML.

### DIFF
--- a/sfml-window/window/Window.cpp
+++ b/sfml-window/window/Window.cpp
@@ -170,7 +170,7 @@ static VALUE Window_GetEvent( VALUE self )
 	sf::Event event;
 	sf::Window *window = NULL;
 	Data_Get_Struct( self, sf::Window, window );
-	if( window->GetEvent( event ) == true )
+	if( window->PollEvent( event ) == true )
 	{
 		VALUE rbObject = rb_funcall( globalEventClass, rb_intern( "new" ), 1, INT2FIX( event.Type ) );
 		sf::Event *rubyRawEvent = NULL;


### PR DESCRIPTION
https://github.com/LaurentGomila/SFML/commit/df6874273a72b0de5a9bccf0b8003f181f69af61

I've only renamed the call that was preventing compilation. You'll probably want to rename the Ruby binding too.
