### PR TITLE
Small Fixes for Samples

### DIFF
--- a/samples/sound.rb
+++ b/samples/sound.rb
@@ -68,5 +68,5 @@ play_sound
 play_music
 
 # Wait until the user presses 'enter' key
-puts "Press enter to exit..."
+print "Press enter to exit..."
 gets

--- a/samples/window.rb
+++ b/samples/window.rb
@@ -9,7 +9,7 @@ rescue LoadError
 end
 
 begin
-  require 'opengl' # from ruby-opengl gem
+  require 'opengl'
 rescue LoadError
   puts "This sample requires the opengl gem"
   print "Press enter to exit..."


### PR DESCRIPTION
Made samples `require` the latest build of rbSFML rather than the installed rbSFML. This makes it easier to test new samples without affecting a working rbSFML install.

Print a helpful message for the LoadError for the opengl gem. This way people running `rake samples` for the first time will know to install the gem without looking at the sample's source.
