### PR TITLE
Had to edit Rakefile to compile on Linux

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ RakeFileUtils.verbose_flag = false
 OBJ_DIR = 'obj'
 SO_DIR = 'lib/sfml'
 DOC_DIR = 'doc'
-EXT_DIR = 'ext'
+EXT_DIR = './ext'
 INST_DIR = File.join(CONFIG['sitearchdir'], SO_DIR)
 
 SFML_INC = ENV['SFML_INCLUDE']


### PR DESCRIPTION
I was getting bugs every time 'rbSFML.hpp' was included, to fix it I had to edit the ext folder on the Rakefile to explicitly show that it was on the current folder.

I know that is just a 'workaround' (that works), but I find important to show it to you guys.

Maybe it run OK on Windows & OSX without this quick fix, but this was the only way I find to compile it on Linux (64x_86x, Fedora 18, RVM Ruby 1.9.3)

Sorry, English is not my main language.
