### PR TITLE
Fix Whitespace

### DIFF
--- a/ext/Graphics/VertexArray.cpp
+++ b/ext/Graphics/VertexArray.cpp
@@ -18,7 +18,7 @@
  *
  * 3. This notice may not be removed or altered from any source distribution.
  */
- 
+
 #define GRAPHICS_VERTEX_ARRAY_CPP
 
 #include "VertexArray.hpp"
@@ -28,29 +28,29 @@
 
 void rbVertexArray::Init( VALUE SFML )
 {
-    rbVertexArray::Class = rb_define_class_under( SFML, "VertexArray", rb_cObject );
+	rbVertexArray::Class = rb_define_class_under( SFML, "VertexArray", rb_cObject );
 	rb_include_module( rbVertexArray::Class, rbDrawable::Module );
-	
+
 	// Class methods
 	rb_define_alloc_func( rbVertexArray::Class, rbMacros::Allocate< sf::VertexArray > );
 
-    // Instance methods
-	ext_define_method( rbVertexArray::Class, "initialize",		rbVertexArray::Initialize,			-1 );
-    ext_define_method( rbVertexArray::Class, "initialize_copy",	rbVertexArray::InitializeCopy,		 1 );
-	ext_define_method( rbVertexArray::Class, "vertex_count",	rbVertexArray::GetVertexCount,		 0 );
-	ext_define_method( rbVertexArray::Class, "append", 			rbVertexArray::Append,				 1 );
-	ext_define_method( rbVertexArray::Class, "[]", 				rbVertexArray::IndexOperator,		 1 );
-	ext_define_method( rbVertexArray::Class, "clear", 			rbVertexArray::Clear,				 0 );
-	ext_define_method( rbVertexArray::Class, "resize", 			rbVertexArray::Resize,				 1 );
-	ext_define_method( rbVertexArray::Class, "primitive_type=",	rbVertexArray::SetPrimitiveType,	 1 );
-	ext_define_method( rbVertexArray::Class, "primitive_type",	rbVertexArray::GetPrimitiveType,	 0 );
-	ext_define_method( rbVertexArray::Class, "bounds",			rbVertexArray::GetBounds,			 0 );
-	ext_define_method( rbVertexArray::Class, "marshal_dump",    rbVertexArray::MarshalDump,			 0 );
-    ext_define_method( rbVertexArray::Class, "==",              rbVertexArray::Equal,				 1 );
-    ext_define_method( rbVertexArray::Class, "inspect",         rbVertexArray::Inspect,				 0 );
+	// Instance methods
+	ext_define_method( rbVertexArray::Class, "initialize",      rbVertexArray::Initialize,       -1 );
+	ext_define_method( rbVertexArray::Class, "initialize_copy", rbVertexArray::InitializeCopy,    1 );
+	ext_define_method( rbVertexArray::Class, "vertex_count",    rbVertexArray::GetVertexCount,    0 );
+	ext_define_method( rbVertexArray::Class, "append",          rbVertexArray::Append,            1 );
+	ext_define_method( rbVertexArray::Class, "[]",              rbVertexArray::IndexOperator,     1 );
+	ext_define_method( rbVertexArray::Class, "clear",           rbVertexArray::Clear,             0 );
+	ext_define_method( rbVertexArray::Class, "resize",          rbVertexArray::Resize,            1 );
+	ext_define_method( rbVertexArray::Class, "primitive_type=", rbVertexArray::SetPrimitiveType,  1 );
+	ext_define_method( rbVertexArray::Class, "primitive_type",  rbVertexArray::GetPrimitiveType,  0 );
+	ext_define_method( rbVertexArray::Class, "bounds",          rbVertexArray::GetBounds,         0 );
+	ext_define_method( rbVertexArray::Class, "marshal_dump",    rbVertexArray::MarshalDump,       0 );
+	ext_define_method( rbVertexArray::Class, "==",              rbVertexArray::Equal,             1 );
+	ext_define_method( rbVertexArray::Class, "inspect",         rbVertexArray::Inspect,           0 );
 
-    // Instance aliases
-    rb_define_alias( rbVertexArray::Class, "to_s",               "inspect"         );
+	// Instance aliases
+	rb_define_alias( rbVertexArray::Class, "to_s",               "inspect"         );
 	rb_define_alias( rbVertexArray::Class, "vertexCount",        "vertex_count"    );
 	rb_define_alias( rbVertexArray::Class, "getVertexCount",     "vertex_count"    );
 	rb_define_alias( rbVertexArray::Class, "get_vertex_count",   "vertex_count"    );
@@ -70,13 +70,13 @@ VALUE rbVertexArray::Initialize( int argc, VALUE* args, VALUE aSelf )
 {;
 	switch( argc )
 	{
-	case 2:
-		rbMacros::ToSFML< sf::VertexArray >( aSelf, rbVertexArray::Class )->resize( NUM2UINT( args[ 1 ] ) );
-	case 1:
-		rbMacros::ToSFML< sf::VertexArray >( aSelf, rbVertexArray::Class )->setPrimitiveType( static_cast< sf::PrimitiveType >( NUM2UINT( args[ 0 ] ) ) );
-		break;
-	default:
-		INVALID_ARGUMENT_LIST( argc, "1 or 2" );
+		case 2:
+			rbMacros::ToSFML< sf::VertexArray >( aSelf, rbVertexArray::Class )->resize( NUM2UINT( args[ 1 ] ) );
+		case 1:
+			rbMacros::ToSFML< sf::VertexArray >( aSelf, rbVertexArray::Class )->setPrimitiveType( static_cast< sf::PrimitiveType >( NUM2UINT( args[ 0 ] ) ) );
+			break;
+		default:
+			INVALID_ARGUMENT_LIST( argc, "1 or 2" );
 	}
 	rb_iv_set( aSelf, "@__internal__drawable_offset", INT2FIX( 0 ) );
 	rb_call_super( 0, NULL );
@@ -88,7 +88,7 @@ VALUE rbVertexArray::InitializeCopy( VALUE aSelf, VALUE aSource )
 {
 	rb_iv_set( aSelf, "@__internal__drawable_offset", INT2FIX( 0 ) );
 	*rbMacros::ToSFML< sf::VertexArray >( aSelf, rbVertexArray::Class ) = *rbMacros::ToSFML< sf::VertexArray >( aSelf, rbVertexArray::Class );
-    return aSelf;
+	return aSelf;
 }
 
 // VertexArray#vertex_count
@@ -146,16 +146,16 @@ VALUE rbVertexArray::GetBounds( VALUE aSelf )
 // VertexArray#marshal_dump
 VALUE rbVertexArray::MarshalDump( VALUE aSelf )
 {
-    rb_raise( rb_eTypeError, "can't dump %s", rb_obj_classname( aSelf ) );
+	rb_raise( rb_eTypeError, "can't dump %s", rb_obj_classname( aSelf ) );
 	return Qnil;
 }
 
 // VertexArray#==(other)
 VALUE rbVertexArray::Equal( VALUE aSelf, VALUE anOther )
 {
-    if( !rb_obj_is_kind_of( anOther, rbVertexArray::Class ) )
+	if( !rb_obj_is_kind_of( anOther, rbVertexArray::Class ) )
 		return Qfalse;
-    else if( rbMacros::ToSFML< sf::VertexArray >( aSelf, rbVertexArray::Class ) == rbMacros::ToSFML< sf::VertexArray >( anOther, rbVertexArray::Class ) )
+	else if( rbMacros::ToSFML< sf::VertexArray >( aSelf, rbVertexArray::Class ) == rbMacros::ToSFML< sf::VertexArray >( anOther, rbVertexArray::Class ) )
 		return Qtrue;
 	else
 		return Qfalse;
@@ -166,6 +166,6 @@ VALUE rbVertexArray::Equal( VALUE aSelf, VALUE anOther )
 VALUE rbVertexArray::Inspect( VALUE aSelf )
 {
 	return rb_sprintf( "%s(%p)",
-					   rb_obj_classname( aSelf ),
-					   rbMacros::ToSFML< sf::VertexArray >( aSelf, rbVertexArray::Class ) );
+			rb_obj_classname( aSelf ),
+			rbMacros::ToSFML< sf::VertexArray >( aSelf, rbVertexArray::Class ) );
 }

--- a/ext/Graphics/VertexArray.hpp
+++ b/ext/Graphics/VertexArray.hpp
@@ -31,59 +31,59 @@
 namespace rbVertexArray
 {
 #if defined( GRAPHICS_VERTEX_ARRAY_CPP )
-    VALUE Class;
+	VALUE Class;
 #else
-    extern VALUE Class;
+	extern VALUE Class;
 #endif
 
 #if defined( RBSFML_GRAPHICS )
-    void Init( VALUE SFML );
+	void Init( VALUE SFML );
 #endif
 
 #if defined( GRAPHICS_VERTEX_ARRAY_CPP )
-    // VertexArray#initialize
+	// VertexArray#initialize
 	// VertexArray#initialize(primitive_type, vertex_count = 0)
-    static VALUE Initialize( int argc, VALUE* args, VALUE aSelf );
-	
+	static VALUE Initialize( int argc, VALUE* args, VALUE aSelf );
+
 	// VertexArray#initialize_copy(source)
-    static VALUE InitializeCopy( VALUE aSelf, VALUE aSource );
-	
+	static VALUE InitializeCopy( VALUE aSelf, VALUE aSource );
+
 	// VertexArray#vertex_count
 	static VALUE GetVertexCount( VALUE aSelf );
-	
+
 	// VertexArray#append(vertex)
 	static VALUE Append( VALUE aSelf, VALUE aVertex );
-	
+
 	// VertexArray#[index]
 	static VALUE IndexOperator( VALUE aSelf, VALUE anIndex );
-	
+
 	// VertexArray#clear
 	static VALUE Clear( VALUE aSelf );
-	
+
 	// VertexArray#resize(vertex_count)
 	static VALUE Resize( VALUE aSelf, VALUE aVertexCount );
-	
+
 	// VertexArray#primitive_type=(type)
 	static VALUE SetPrimitiveType( VALUE aSelf, VALUE aType );
-	
+
 	// VertexArray#primitive_type
 	static VALUE GetPrimitiveType( VALUE aSelf );
-	
+
 	// VertexArray#bounds
 	static VALUE GetBounds( VALUE aSelf );
-	
+
 	// VertexArray#draw(render_target, render_states)
 	static VALUE Draw( VALUE aSelf, VALUE aRenderTarget, VALUE aRenderStates );
-	
-    // VertexArray#marshal_dump
-    static VALUE MarshalDump( VALUE aSelf );
 
-    // VertexArray#==(other)
-    static VALUE Equal( VALUE aSelf, VALUE anOther );
+	// VertexArray#marshal_dump
+	static VALUE MarshalDump( VALUE aSelf );
 
-    // VertexArray#inspect
-    // VertexArray#to_s
-    static VALUE Inspect( VALUE aSelf );
+	// VertexArray#==(other)
+	static VALUE Equal( VALUE aSelf, VALUE anOther );
+
+	// VertexArray#inspect
+	// VertexArray#to_s
+	static VALUE Inspect( VALUE aSelf );
 #endif
 }
 


### PR DESCRIPTION
This is a bit OCD :]

Unlike the rest of rbSFML, VertexArray.cpp and hpp used Windows-style CRLF line endings.  Also they put tabs in the middle of text so that text would align weird for different tab sizes (e.g. when viewing code on github). I fixed all that.
